### PR TITLE
Add Hazmat to Tools, Utilities & Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ getmacosipsws.py: https://github.com/munki/macadmin-scripts<br />
 Giphy Capture: https://itunes.apple.com/us/app/giphy-capture-the-gif-maker/id668208984?mt=12<br />
 Google Keep: https://www.google.com/keep/<br />
 Graham Pugh multitenant Jamf Pro tools: https://github.com/grahampugh/multitenant-jamf-tools<br />
+Hazmat - macOS containment for AI coding agents and risky local scripts: https://github.com/dredozubov/hazmat<br />
 Hello-IT: https://github.com/ygini/Hello-IT<br />
 IBM Migration Tool: https://github.com/IBM/mac-ibm-migration-tool<br />
 Icons.app: https://github.com/SAP/macOS-icon-generator<br />


### PR DESCRIPTION
Adding Hazmat under Tools, Utilities & Scripts.

Hazmat is a macOS containment CLI for AI coding agents and risky local scripts. The work runs under its own UID (not the admin's), under a Seatbelt policy applied via `sandbox_init()` from a small privileged helper (not `sandbox-exec`), with PF anchors and DNS blocklists for per-session network policy, plus backup/rollback for reversible host setup.

The design is checked in TLA+ across nine specs (~44,795 states) covering setup/rollback ordering, seatbelt credential-deny policy, backup safety, version migration, Tier 2/Tier 3 policy equivalence, session-time host permission repairs, harness lifecycle, and helper fd hygiene before `sandbox_init`.

https://github.com/dredozubov/hazmat
