### PR TITLE
Add Nexus Shell to Tools, Utilities & Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ MIST – macOS Installer Super Tool: https://github.com/ninxsoft/Mist<br />
 moss: https://github.com/WardsParadox/moss<br />
 Munki: https://github.com/munki/munki<br />
 munki-pkg: https://github.com/munki/munki-pkg<br />
+Nexus Shell: https://nexusshell.app/<br />
 NoMAD: https://nomad.menu/products/#nomad<br />
 Nova: https://nova.app/<br />
 Nudge: https://github.com/macadmins/nudge<br />


### PR DESCRIPTION
Adds Nexus Shell to the Tools, Utilities & Scripts section using the project's existing one-line format.

I am the developer of Nexus Shell. It is a native macOS SSH workspace for managing servers and remote files, and the linked homepage is the canonical product URL. Basic personal SSH use is free; the current app requires Apple silicon and macOS 14.2 or later.

This pull request was prepared with assistance from Codex using GPT-5. I verified the placement, product facts, and destination URL before submission.